### PR TITLE
Checkout

### DIFF
--- a/lib/vagrant-saltdeps/provisioner.rb
+++ b/lib/vagrant-saltdeps/provisioner.rb
@@ -41,6 +41,7 @@ module VagrantPlugins
             g = Git.clone(uri, name, path: @checkout_path)
           end
           g.checkout(branch)
+          g.pull
         end
       end
 

--- a/lib/vagrant-saltdeps/provisioner.rb
+++ b/lib/vagrant-saltdeps/provisioner.rb
@@ -40,8 +40,7 @@ module VagrantPlugins
           else
             g = Git.clone(uri, name, path: @checkout_path)
           end
-          g.branch(branch).checkout
-          g.fetch
+          g.checkout(branch)
         end
       end
 

--- a/lib/vagrant-saltdeps/version.rb
+++ b/lib/vagrant-saltdeps/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Saltdeps
-    VERSION = '1.0.2'
+    VERSION = '1.0.3'
   end
 end


### PR DESCRIPTION
From my testing, g.branch(branch).checkout creates a new branch, whereas g.checkout(branch) behaves just like git checkout branch, checking out the remote branch.

One thing that is not covered is verifying that the branch exists. Not sure if the plugin will crash on a non-existant remote branch. 
