### PR TITLE
Error handling v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ build/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+.idea/
+*.iml

--- a/CHANGLOG.md
+++ b/CHANGLOG.md
@@ -1,3 +1,15 @@
+## 1.0.4 (2015-04-03)
+
+ErrorHandling:
+
+  - exit on error if the branch defined in saltdeps.yml does not exist in the repository.
+
+## 1.0.3 (2015-04-03)
+
+Bugfixes:
+
+  - when a branch is defined for a repository in saltdeps.yml, do a checkout of the remote branch.
+
 ## 1.0.2 (2015-03-31)
 
 Bugfixes:

--- a/lib/vagrant-saltdeps.rb
+++ b/lib/vagrant-saltdeps.rb
@@ -6,6 +6,6 @@ module VagrantPlugins
     def self.source_root
       @source_root ||= Pathname.new(File.expand_path("../../", __FILE__))
     end
-    
-  end
+     I18n.load_path += Dir[File.expand_path("../../locales/*{rb,yml}", __FILE__)]
+   end
 end

--- a/lib/vagrant-saltdeps/errors.rb
+++ b/lib/vagrant-saltdeps/errors.rb
@@ -1,0 +1,12 @@
+
+
+module VagrantPlugins
+  module Saltdeps
+    class GitCheckoutError < Vagrant::Errors::VagrantError
+      error_key "git_checkout_error"
+    end
+    class UnknownException < Vagrant::Errors::VagrantError
+      error_key "unknown_error"
+    end
+  end
+end

--- a/lib/vagrant-saltdeps/provisioner.rb
+++ b/lib/vagrant-saltdeps/provisioner.rb
@@ -3,7 +3,7 @@ require 'vagrant'
 require 'git'
 require 'fileutils'
 require "log4r"
-
+require_relative 'errors'
 
 module VagrantPlugins
   module Saltdeps
@@ -40,8 +40,12 @@ module VagrantPlugins
           else
             g = Git.clone(uri, name, path: @checkout_path)
           end
-          g.checkout(branch)
-          g.pull
+          begin
+            g.checkout(branch)
+            g.pull
+          rescue  Git::GitExecuteError => e
+            raise GitCheckoutError.new :branch => branch, :message => e.message
+          end
         end
       end
 

--- a/lib/vagrant-saltdeps/version.rb
+++ b/lib/vagrant-saltdeps/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Saltdeps
-    VERSION = '1.0.3'
+    VERSION = '1.0.4'
   end
 end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -3,7 +3,7 @@ en:
     errors:
       git_checkout_error: |-
         Saltdeps experienced a git error checking out branch '%{branch}'.
-        Are you sure that branch exists in the repository?
+        Are you sure that branch defined in saltdeps.yml exists in the repository?
 
         git returned:
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,0 +1,15 @@
+en:
+  vagrant:
+    errors:
+      git_checkout_error: |-
+        Saltdeps experienced a git error checking out branch '%{branch}'.
+        Are you sure that branch exists in the repository?
+
+        git returned:
+
+        %{message}
+
+      unknown_error: |-
+        Saldeps experienced an unknown error. The message was:
+
+        %{message}


### PR DESCRIPTION
Add exception class GitCheckoutError that exits vagrant if the branch defined in saltdeps.yml for the dependent repository does not exist.

For example:

Bringing machine 'default' up with 'virtualbox' provider...
==> default: Checking if box 'ubuntu/trusty64' is up to date...
Saltdeps experienced a git error checking out branch 'bogus_branch'.
Are you sure that branch defined in saltdeps.yml exists in the repository?

git returned:

git '--git-dir=~/vagrant/some-formula/.vagrant-salt/deps/dependent-formula/.git' '--work-tree=~/vagrant/some-formula/.vagrant-salt/deps/dependent-formula' checkout 'bogus_branch'  2>&1:error: pathspec 'bogus_branch' did not match any file(s) known to git.
